### PR TITLE
Fix prompt-rows func

### DIFF
--- a/src/pegthing/core.clj
+++ b/src/pegthing/core.clj
@@ -237,7 +237,7 @@
 (defn prompt-rows
   "Ask how many rows the new board have"
   []
-  (print "How many rows? [5]")
+  (println "How many rows? [5]")
   (let [rows (Integer. (get-input 5))
         board (new-board rows)]
     (prompt-empty-peg board)))


### PR DESCRIPTION
- Replace `print` with `println`
- Fixes issue #8